### PR TITLE
Update ArrayConfiguration to handle missing keys

### DIFF
--- a/src/ArrayConfiguration.php
+++ b/src/ArrayConfiguration.php
@@ -4,17 +4,34 @@ namespace Cspray\Labrador\Http\Cors;
 
 final class ArrayConfiguration implements Configuration {
 
+    private const REQUIRED_KEYS = ['origin', 'allowed_methods'];
+
     private $configuration;
 
     public function __construct(array $configuration) {
+        $badKeys = $this->checkForBadKeys($configuration);
+        if (!empty($badKeys)) {
+            $msg = sprintf('An array with keys [%s] MUST be provided with non-empty values', implode(', ', $badKeys));
+            throw new \InvalidArgumentException($msg);
+        }
         $this->configuration = $configuration;
+    }
+
+    private function checkForBadKeys(array $configuration) : array {
+        $badKeys = [];
+        foreach (self::REQUIRED_KEYS as $requiredKey) {
+            if (!isset($configuration[$requiredKey]) || empty($configuration[$requiredKey])) {
+                $badKeys[] = $requiredKey;
+            }
+        }
+        return $badKeys;
     }
 
     /**
      * Return the Origin that this CORS Configuration is valid for.
      *
      * If the Origin header in the OPTIONS request matches this value the rest of this Configuration will determine
-     *the headers that are returned. If no Configuration is present for the Origin is not allowed.
+     * the headers that are returned. If no Configuration is present for the Origin is not allowed.
      *
      * @return string
      */
@@ -27,8 +44,8 @@ final class ArrayConfiguration implements Configuration {
      *
      * @return int
      */
-    public function getMaxAge(): int {
-        return $this->configuration['max_age'];
+    public function getMaxAge() : ?int {
+        return $this->configuration['max_age'] ?? null;
     }
 
     /**
@@ -36,7 +53,7 @@ final class ArrayConfiguration implements Configuration {
      *
      * @return string[]
      */
-    public function getAllowedMethods(): array {
+    public function getAllowedMethods() : array {
         return $this->configuration['allowed_methods'];
     }
 
@@ -45,8 +62,8 @@ final class ArrayConfiguration implements Configuration {
      *
      * @return array
      */
-    public function getAllowedHeaders(): array {
-        return $this->configuration['allowed_headers'];
+    public function getAllowedHeaders() : array {
+        return $this->configuration['allowed_headers'] ?? [];
     }
 
     /**
@@ -56,7 +73,7 @@ final class ArrayConfiguration implements Configuration {
      * @return string[]
      */
     public function getExposableHeaders(): array {
-        return $this->configuration['exposable_headers'];
+        return $this->configuration['exposable_headers'] ?? [];
     }
 
     /**
@@ -65,6 +82,6 @@ final class ArrayConfiguration implements Configuration {
      * @return bool
      */
     public function shouldAllowCredentials(): bool {
-        return $this->configuration['allow_credentials'];
+        return $this->configuration['allow_credentials'] ?? false;
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -19,7 +19,7 @@ interface Configuration {
      *
      * @return int
      */
-    public function getMaxAge() : int;
+    public function getMaxAge() : ?int;
 
     /**
      * Return the HTTP methods that are supported for cross-origin requests with this origin.

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -23,9 +23,9 @@ final class CorsMiddleware implements Middleware {
      * @param Request $request
      * @param RequestHandler $requestHandler
      *
-     * @return Promise<\Amp\Http\Server\Response>
+     * @return Promise<Response>
      */
-    public function handleRequest(Request $request, RequestHandler $requestHandler): Promise {
+    public function handleRequest(Request $request, RequestHandler $requestHandler) : Promise {
         return call(function() use($request, $requestHandler) {
             if ($request->getMethod() === 'OPTIONS') {
                 return $this->handleOptionRequest($request);
@@ -79,7 +79,11 @@ final class CorsMiddleware implements Middleware {
             if ($this->configuration->shouldAllowCredentials()) {
                 $response->setHeader('Access-Control-Allow-Credentials', 'true');
             }
-            $response->setHeader('Access-Control-Max-Age', $this->configuration->getMaxAge());
+
+            $maxAge = $this->configuration->getMaxAge();
+            if (isset($maxAge)) {
+                $response->setHeader('Access-Control-Max-Age', $this->configuration->getMaxAge());
+            }
         }
 
         return $response;

--- a/test/ArrayConfigurationTest.php
+++ b/test/ArrayConfigurationTest.php
@@ -46,4 +46,44 @@ class ArrayConfigurationTest extends TestCase {
         $this->assertTrue($this->subject()->shouldAllowCredentials());
     }
 
+    public function testRequiredKeysNotGivenThrowsException() {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An array with keys [origin, allowed_methods] MUST be provided with non-empty values');
+
+        new ArrayConfiguration([]);
+    }
+
+    public function testEmptyRequiredKeysGivenThrowsException() {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An array with keys [origin, allowed_methods] MUST be provided with non-empty values');
+
+        new ArrayConfiguration(['origin' => '', 'allowed_methods' => []]);
+    }
+
+    public function testDefaultMaxAgeValue() {
+        $subject = new ArrayConfiguration(['origin' => 'https://example.com', 'allowed_methods' => ['GET']]);
+
+        $this->assertNull($subject->getMaxAge());
+    }
+
+    public function testDefaultAllowedHeaders() {
+        $subject = new ArrayConfiguration(['origin' => 'https://example.com', 'allowed_methods' => ['GET']]);
+
+        $this->assertIsArray($subject->getAllowedHeaders());
+        $this->assertEmpty($subject->getAllowedHeaders());
+    }
+
+    public function testDefaultExposableHeaders() {
+        $subject = new ArrayConfiguration(['origin' => 'https://example.com', 'allowed_methods' => ['GET']]);
+
+        $this->assertIsArray($subject->getExposableHeaders());
+        $this->assertEmpty($subject->getExposableHeaders());
+    }
+
+    public function testDefaultShouldAllowCredentials() {
+        $subject = new ArrayConfiguration(['origin' => 'https://example.com', 'allowed_methods' => ['GET']]);
+
+        $this->assertFalse($subject->shouldAllowCredentials());
+    }
+
 }

--- a/test/CorsMiddlewareTest.php
+++ b/test/CorsMiddlewareTest.php
@@ -304,4 +304,25 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $this->assertNull($actualResponse->getHeader('Access-Control-Max-Age'));
     }
 
+    public function testNoMaxAgeSetDoesNotSetHeader() {
+        $request = $this->createRequest('OPTIONS', '/some/path', [
+            'Access-Control-Request-Method' => 'GET'
+        ]);
+        $mock = $this->createMock(RequestHandler::class);
+        $mock->expects($this->never())
+            ->method('handleRequest');
+
+        $middleware = new CorsMiddleware($this->configuration(['max_age' => null]));
+        /** @var Response $actualResponse */
+        $actualResponse = yield $middleware->handleRequest($request, $mock);
+
+        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame('https://labrador.example.com', $actualResponse->getHeader('Access-Control-Allow-Origin'));
+        $this->assertSame('GET, POST, PUT, DELETE', $actualResponse->getHeader('Access-Control-Allow-Methods'));
+        $this->assertSame('X-Custom-Req-Header, Content-Type', $actualResponse->getHeader('Access-Control-Allow-Headers'));
+        $this->assertSame('X-Custom-Res-Header', $actualResponse->getHeader('Access-Control-Expose-Headers'));
+        $this->assertSame('true', $actualResponse->getHeader('Access-Control-Allow-Credentials'));
+        $this->assertFalse($actualResponse->hasHeader('Access-Control-Max-Age'));
+    }
+
 }


### PR DESCRIPTION
It is possible that not all keys would be provided to the
ArrayConfiguration instance because the end developer wanted to use
browser default values. This was particularly true of the `max_age` key.
The ArrayConfiguration instance now handles when optional keys are not
provided and returns reasonable "null values".

If the ArrayConfiguration does not receive AT LEAST an array with keys
`origin` and `allowed_methods` an exception will be thrown because CORS
doesn't make sense without at least this information.

This addresses issue #6