### PR TITLE
Allow no methods to be defined for Origin

### DIFF
--- a/src/ArrayConfiguration.php
+++ b/src/ArrayConfiguration.php
@@ -4,7 +4,7 @@ namespace Cspray\Labrador\Http\Cors;
 
 final class ArrayConfiguration implements Configuration {
 
-    private const REQUIRED_KEYS = ['origins', 'allowed_methods'];
+    private const REQUIRED_KEYS = ['origins'];
 
     private $configuration;
 
@@ -54,7 +54,7 @@ final class ArrayConfiguration implements Configuration {
      * @return string[]
      */
     public function getAllowedMethods() : array {
-        return $this->configuration['allowed_methods'];
+        return $this->configuration['allowed_methods'] ?? [];
     }
 
     /**

--- a/src/ConfigurationBuilder.php
+++ b/src/ConfigurationBuilder.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 class ConfigurationBuilder {
 
     private $origins;
-    private $methods;
+    private $methods = [];
     private $allowedHeaders = [];
     private $exposableHeaders = [];
     private $maxAge;
@@ -56,9 +56,6 @@ class ConfigurationBuilder {
     }
 
     public function build() : Configuration {
-        if (empty($this->methods)) {
-            throw new InvalidArgumentException('At least one HTTP method must be provided when building a Configuration');
-        }
         return new class($this->origins, $this->methods, $this->maxAge, $this->allowedHeaders, $this->exposableHeaders, $this->allowCredentials) implements Configuration {
             private $origins;
             private $methods;

--- a/test/ArrayConfigurationTest.php
+++ b/test/ArrayConfigurationTest.php
@@ -47,40 +47,47 @@ class ArrayConfigurationTest extends TestCase {
 
     public function testRequiredKeysNotGivenThrowsException() {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('An array with keys [origins, allowed_methods] MUST be provided with non-empty values');
+        $this->expectExceptionMessage('An array with keys [origins] MUST be provided with non-empty values');
 
         new ArrayConfiguration([]);
     }
 
     public function testEmptyRequiredKeysGivenThrowsException() {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('An array with keys [origins, allowed_methods] MUST be provided with non-empty values');
+        $this->expectExceptionMessage('An array with keys [origins] MUST be provided with non-empty values');
 
-        new ArrayConfiguration(['origins' => [], 'allowed_methods' => []]);
+        new ArrayConfiguration(['origins' => []]);
+    }
+
+    public function testDefaultAllowedMethods() {
+        $subject = new ArrayConfiguration(['origins' => ['https://example.com']]);
+
+        $this->assertIsArray($subject->getAllowedMethods());
+        $this->assertEmpty($subject->getAllowedMethods());
     }
 
     public function testDefaultMaxAgeValue() {
-        $subject = new ArrayConfiguration(['origins' => ['https://example.com'], 'allowed_methods' => ['GET']]);
+        $subject = new ArrayConfiguration(['origins' => ['https://example.com']]);
 
         $this->assertNull($subject->getMaxAge());
     }
 
     public function testDefaultAllowedHeaders() {
-        $subject = new ArrayConfiguration(['origins' => ['https://example.com'], 'allowed_methods' => ['GET']]);
+        $subject = new ArrayConfiguration(['origins' => ['https://example.com']]);
 
         $this->assertIsArray($subject->getAllowedHeaders());
         $this->assertEmpty($subject->getAllowedHeaders());
     }
 
     public function testDefaultExposableHeaders() {
-        $subject = new ArrayConfiguration(['origins' => ['https://example.com'], 'allowed_methods' => ['GET']]);
+        $subject = new ArrayConfiguration(['origins' => ['https://example.com']]);
 
         $this->assertIsArray($subject->getExposableHeaders());
         $this->assertEmpty($subject->getExposableHeaders());
     }
 
     public function testDefaultShouldAllowCredentials() {
-        $subject = new ArrayConfiguration(['origins' => ['https://example.com'], 'allowed_methods' => ['GET']]);
+        $subject = new ArrayConfiguration(['origins' => ['https://example.com']]);
 
         $this->assertFalse($subject->shouldAllowCredentials());
     }

--- a/test/ConfigurationBuilderTest.php
+++ b/test/ConfigurationBuilderTest.php
@@ -13,14 +13,6 @@ class ConfigurationBuilderTest extends TestCase {
         ConfigurationBuilder::forOrigins();
     }
 
-    public function testNoMethodsThrowsError() {
-        $builder = ConfigurationBuilder::forOrigins('https://example.com')->allowMethods();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('At least one HTTP method must be provided when building a Configuration');
-
-        $builder->build();
-    }
-
     public function testBuildCompleteConfiguration() {
         $configuration = ConfigurationBuilder::forOrigins('https://example.com')
             ->allowMethods('GET', 'POST', 'DELETE')
@@ -39,12 +31,10 @@ class ConfigurationBuilderTest extends TestCase {
     }
 
     public function testBuildMinimalConfigurationWithDefaultValues() {
-        $configuration = ConfigurationBuilder::forOrigins('https://example.com', 'https://foo.com')
-            ->allowMethods('GET', 'POST', 'DELETE')
-            ->build();
+        $configuration = ConfigurationBuilder::forOrigins('https://example.com', 'https://foo.com')->build();
 
         $this->assertSame(['https://example.com', 'https://foo.com'], $configuration->getOrigins());
-        $this->assertSame(['GET', 'POST', 'DELETE'], $configuration->getAllowedMethods());
+        $this->assertSame([], $configuration->getAllowedMethods());
         $this->assertSame([], $configuration->getAllowedHeaders());
         $this->assertSame([], $configuration->getExposableHeaders());
         $this->assertNull($configuration->getMaxAge());


### PR DESCRIPTION
It was discovered through the course of documenting expected user cases
that a user might want to create a Configuration that specifies an
Origin is allowed to perform no HTTP methods. For example, if creating a
ConfigurationLoader and you encounter a Request you cannot reasonably
create a Configuration for you could create one on-the-fly for that
specific Origin that denies them access to any HTTP method.