### PR TITLE
Do not handle requests with no Origin header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ opposed to the ArrayConfiguration instance.
 not need to be explicitly set and using the browser default is preferred.
 - Updates the ArrayConfiguration instance to handle when a key is not present and ensures that required 
 values are passed in the constructor.
+- Changed the `CorsMiddleware` to only process non-OPTION requests if there is an Origin header present. This should 
+not be a BC break as if there was no Origin header in the Request it wouldn't add headers to the Response.
 - **BC BREAK** Renamed `Configuration::getOrigin()` -> `Configuration::getOrigins()` and it now expects an array of 
-string instead of just one. The thought process being that the rules that apply to 1 Origin is likely to 
+strings instead of just one. The thought process being that the rules that apply to 1 Origin is likely to 
 apply to another.
 - **BC BREAK** Changed the `CorsMiddleware` instance to require a `ConfigurationLoader` instead of a `Configuration` instance.
 

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -42,19 +42,21 @@ final class CorsMiddleware implements Middleware {
             /** @var Response $response */
             $response = yield $requestHandler->handleRequest($request);
 
-            $configuration = $this->configurationLoader->loadConfiguration($request);
-            $origins = $configuration->getOrigins();
-            $hasWildCardOrigin = in_array('*', $origins, true);
-            $originHeader = $request->getHeader('Origin');
-            $originHeaderMatches = in_array($originHeader, $origins, true);
-            $originResponseHeader = $hasWildCardOrigin ? '*' : $originHeader;
-            if ($hasWildCardOrigin || $originHeaderMatches) {
-                $response->setHeader('Access-Control-Allow-Origin', $originResponseHeader);
-                $varyHeader = $response->getHeader('Vary');
-                $varyHeader = isset($varyHeader) ? $varyHeader . ', Origin' : 'Origin';
-                $response->setHeader('Vary', $varyHeader);
-                if ($configuration->shouldAllowCredentials()) {
-                    $response->setHeader('Access-Control-Allow-Credentials', 'true');
+            if ($request->hasHeader('Origin')) {
+                $configuration = $this->configurationLoader->loadConfiguration($request);
+                $origins = $configuration->getOrigins();
+                $hasWildCardOrigin = in_array('*', $origins, true);
+                $originHeader = $request->getHeader('Origin');
+                $originHeaderMatches = in_array($originHeader, $origins, true);
+                $originResponseHeader = $hasWildCardOrigin ? '*' : $originHeader;
+                if ($hasWildCardOrigin || $originHeaderMatches) {
+                    $response->setHeader('Access-Control-Allow-Origin', $originResponseHeader);
+                    $varyHeader = $response->getHeader('Vary');
+                    $varyHeader = isset($varyHeader) ? $varyHeader . ', Origin' : 'Origin';
+                    $response->setHeader('Vary', $varyHeader);
+                    if ($configuration->shouldAllowCredentials()) {
+                        $response->setHeader('Access-Control-Allow-Credentials', 'true');
+                    }
                 }
             }
 


### PR DESCRIPTION
Going through the ConfigurationLoader process and the necessary logic to
determine if CORS headers should be added for a Response if no Origin
header is present doesn't make sense. We know before any of the
processing that an Origin header with no value will never match any of
our expected logic and we can skip over this potentially costly step for
requests that do not require it.