### PR TITLE
:sparkles: Support for amphp v3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,28 +10,25 @@ jobs:
   build-test:
 
     runs-on: ubuntu-latest
+    name: Run tests (${{ matrix.php }})
+
+    strategy:
+      matrix:
+        php: [8.1, 8.2]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Composer 7
-        uses: php-actions/composer@v5
-        with:
-          php_version: 7
-      - name: PHP 7 tests
-        uses: php-actions/phpunit@v2
-        with:
-          version: 9
-          php_version: 7
 
-      - name: Composer 8
-        uses: php-actions/composer@v5
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          php_version: 8
-      - name: PHP 8 tests
-        uses: php-actions/phpunit@v2
-        with:
-          version: 9
-          php_version: 8
+          php-version: ${{ matrix.php }}
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: PHPUnit ${{ matrix.php }} tests
+        run: ./vendor/bin/phpunit
 
       - name: Run code sniffer
         run: composer run code-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Add support for amphp v3
+- Add support for PHP 8.1 & 8.2
+
+### Removed
+
+- Support for amphp v1 & v2
+- Support for PHP < 8.1
+
 ## 0.3.1 - 2021-06-17
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "prefer-stable": true,
   "require-dev": {
     "phpunit/phpunit": "^9.0",
-    "amphp/phpunit-util": "^1.3",
+    "amphp/phpunit-util": "^3",
     "cspray/labrador-coding-standard": "0.2.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,11 @@
     "test": "vendor/bin/phpunit"
   },
   "require": {
-    "php": "^7.0 || ^8.0",
-    "amphp/http-server": "^1.0 || ^2.0"
+    "php": ">= 8.1",
+    "amphp/http-server": "^3"
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "require-dev": {
     "phpunit/phpunit": "^9.0",
     "amphp/phpunit-util": "^1.3",

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -97,7 +97,7 @@ final class CorsMiddleware implements Middleware {
 
             $maxAge = $configuration->getMaxAge();
             if (isset($maxAge)) {
-                $response->setHeader('Access-Control-Max-Age', $configuration->getMaxAge());
+                $response->setHeader('Access-Control-Max-Age', (string) $maxAge);
             }
         }
 

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -2,14 +2,11 @@
 
 namespace Cspray\Labrador\Http\Cors;
 
+use Amp\Http\HttpStatus;
 use Amp\Http\Server\Middleware;
 use Amp\Http\Server\Request;
 use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\Response;
-use Amp\Http\Status;
-use Amp\Promise;
-
-use function Amp\call;
 
 /**
  * An Amp http-server middleware that is responsible for handling CORS request.
@@ -31,33 +28,30 @@ final class CorsMiddleware implements Middleware {
      * @param Request $request
      * @param RequestHandler $requestHandler
      *
-     * @return Promise<Response>
+     * @return Response
      */
-    public function handleRequest(Request $request, RequestHandler $requestHandler) : Promise {
-        return call(function() use($request, $requestHandler) {
-            if ($request->getMethod() === 'OPTIONS') {
-                return $this->handleOptionRequest($request);
-            }
+    public function handleRequest(Request $request, RequestHandler $requestHandler): Response {
+        if ($request->getMethod() === 'OPTIONS') {
+            return $this->handleOptionRequest($request);
+        }
 
-            /** @var Response $response */
-            $response = yield $requestHandler->handleRequest($request);
+        $response = $requestHandler->handleRequest($request);
 
-            if ($request->hasHeader('Origin')) {
-                $configuration = $this->configurationLoader->loadConfiguration($request);
-                if ($this->doesOriginHeaderMatch($request, $configuration)) {
-                    $originResponseHeader = $this->getOriginResponseHeader($request, $configuration);
-                    $response->setHeader('Access-Control-Allow-Origin', $originResponseHeader);
-                    $varyHeader = $response->getHeader('Vary');
-                    $varyHeader = isset($varyHeader) ? $varyHeader . ', Origin' : 'Origin';
-                    $response->setHeader('Vary', $varyHeader);
-                    if ($configuration->shouldAllowCredentials()) {
-                        $response->setHeader('Access-Control-Allow-Credentials', 'true');
-                    }
+        if ($request->hasHeader('Origin')) {
+            $configuration = $this->configurationLoader->loadConfiguration($request);
+            if ($this->doesOriginHeaderMatch($request, $configuration)) {
+                $originResponseHeader = $this->getOriginResponseHeader($request, $configuration);
+                $response->setHeader('Access-Control-Allow-Origin', $originResponseHeader);
+                $varyHeader = $response->getHeader('Vary');
+                $varyHeader = isset($varyHeader) ? $varyHeader . ', Origin' : 'Origin';
+                $response->setHeader('Vary', $varyHeader);
+                if ($configuration->shouldAllowCredentials()) {
+                    $response->setHeader('Access-Control-Allow-Credentials', 'true');
                 }
             }
+        }
 
-            return $response;
-        });
+        return $response;
     }
 
     private function handleOptionRequest(Request $request) : Response {
@@ -75,9 +69,9 @@ final class CorsMiddleware implements Middleware {
         });
 
         if (!$this->doesOriginHeaderMatch($request, $configuration) || !empty($badCorsHeaders)) {
-            $response->setStatus(Status::FORBIDDEN);
+            $response->setStatus(HttpStatus::FORBIDDEN);
         } elseif (!in_array($corsMethod, $allowedMethods)) {
-            $response->setStatus(Status::METHOD_NOT_ALLOWED);
+            $response->setStatus(HttpStatus::METHOD_NOT_ALLOWED);
         } else {
             $originResponseHeader = $this->getOriginResponseHeader($request, $configuration);
             $response->setHeader('Access-Control-Allow-Origin', $originResponseHeader);

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -24,11 +24,6 @@ final class CorsMiddleware implements Middleware {
     /**
      * Will handle all OPTIONS Requests based on the Configuration for the given Request and ensure all non-OPTIONS
      * requests have appropriate CORS headers.
-     *
-     * @param Request $request
-     * @param RequestHandler $requestHandler
-     *
-     * @return Response
      */
     public function handleRequest(Request $request, RequestHandler $requestHandler): Response {
         if ($request->getMethod() === 'OPTIONS') {

--- a/test/CorsMiddlewareTest.php
+++ b/test/CorsMiddlewareTest.php
@@ -2,13 +2,12 @@
 
 namespace Cspray\Labrador\Http\Cors;
 
+use Amp\Http\HttpStatus;
 use Amp\Http\Server\Driver\Client;
 use Amp\Http\Server\Request;
 use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\Response;
-use Amp\Http\Status;
 use Amp\PHPUnit\AsyncTestCase;
-use Amp\Success;
 use League\Uri\Http;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -48,12 +47,12 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $requestHandler->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success(new Response()));
+            ->willReturn(new Response());
 
         $subject = new CorsMiddleware($loader);
 
         /** @var Response $response */
-        $response = yield $subject->handleRequest($request, $requestHandler);
+        $response = $subject->handleRequest($request, $requestHandler);
 
         $this->assertFalse($response->hasHeader('Access-Control-Allow-Origin'));
     }
@@ -65,10 +64,10 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $middleware = new CorsMiddleware($this->configuration());
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
         $this->assertSame($response, $actualResponse);
     }
@@ -80,12 +79,12 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $middleware = new CorsMiddleware($this->configuration());
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -101,12 +100,12 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $middleware = new CorsMiddleware($this->configuration([
             'allow_credentials' => false
         ]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Credentials'));
     }
@@ -114,16 +113,16 @@ class CorsMiddlewareTest extends AsyncTestCase {
     public function testNonOptionsRequestRespectsExistingVaryHeader() {
         $request = $this->createRequest('GET', '/some/path');
         $mock = $this->createMock(RequestHandler::class);
-        $response = new Response(Status::OK, ['Vary' => 'Content-Type']);
+        $response = new Response(HttpStatus::OK, ['Vary' => 'Content-Type']);
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $middleware = new CorsMiddleware($this->configuration([
             'allow_credentials' => false
         ]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
         $this->assertSame('Content-Type, Origin', $actualResponse->getHeader('Vary'));
     }
@@ -136,12 +135,12 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $middleware = new CorsMiddleware($this->configuration());
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Origin'));
     }
 
@@ -155,15 +154,15 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $config = $this->configuration([
             'origins' => ['*']
         ]);
         $middleware = new CorsMiddleware($config);
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame('*', $actualResponse->getHeader('Access-Control-Allow-Origin'));
         $this->assertSame('true', $actualResponse->getHeader('Access-Control-Allow-Credentials'));
     }
@@ -178,13 +177,13 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $mock->expects($this->once())
             ->method('handleRequest')
             ->with($request)
-            ->willReturn(new Success($response));
+            ->willReturn($response);
 
         $config = $this->configuration();
         $middleware = new CorsMiddleware($config);
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -204,9 +203,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
             ->method('handleRequest');
 
         $middleware = new CorsMiddleware($this->configuration());
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -236,9 +235,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
             ->method('handleRequest');
 
         $middleware = new CorsMiddleware($this->configuration());
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -271,9 +270,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
             'origins' => ['*']
         ]);
         $middleware = new CorsMiddleware($config);
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame('*', $actualResponse->getHeader('Access-Control-Allow-Origin'));
         $this->assertSame(
             'GET, POST, PUT, DELETE',
@@ -304,9 +303,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
             'origins' => ['*']
         ]);
         $middleware = new CorsMiddleware($config);
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame('*', $actualResponse->getHeader('Access-Control-Allow-Origin'));
         $this->assertSame(
             'GET, POST, PUT, DELETE',
@@ -334,9 +333,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $middleware = new CorsMiddleware($this->configuration([
             'allow_credentials' => false
         ]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -364,9 +363,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $middleware = new CorsMiddleware($this->configuration([
             'allowed_headers' => []
         ]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -392,9 +391,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $middleware = new CorsMiddleware($this->configuration([
             'exposable_headers' => []
         ]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')
@@ -421,9 +420,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
             ->method('handleRequest');
 
         $middleware = new CorsMiddleware($this->configuration());
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::FORBIDDEN, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::FORBIDDEN, $actualResponse->getStatus());
         $this->assertNulL($actualResponse->getHeader('Access-Control-Allow-Origin'));
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Methods'));
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Headers'));
@@ -443,9 +442,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
             ->method('handleRequest');
 
         $middleware = new CorsMiddleware($this->configuration(['allowed_methods' => ['GET']]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::METHOD_NOT_ALLOWED, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::METHOD_NOT_ALLOWED, $actualResponse->getStatus());
         $this->assertNulL($actualResponse->getHeader('Access-Control-Allow-Origin'));
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Methods'));
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Headers'));
@@ -467,9 +466,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
         $middleware = new CorsMiddleware($this->configuration([
             'allowed_headers' => ['X-Not-Set-In-Options', 'Content-Type']
         ]));
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::FORBIDDEN, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::FORBIDDEN, $actualResponse->getStatus());
         $this->assertNulL($actualResponse->getHeader('Access-Control-Allow-Origin'));
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Methods'));
         $this->assertNull($actualResponse->getHeader('Access-Control-Allow-Headers'));
@@ -487,9 +486,9 @@ class CorsMiddlewareTest extends AsyncTestCase {
 
         $middleware = new CorsMiddleware($this->configuration(['max_age' => null]));
         /** @var Response $actualResponse */
-        $actualResponse = yield $middleware->handleRequest($request, $mock);
+        $actualResponse = $middleware->handleRequest($request, $mock);
 
-        $this->assertSame(Status::OK, $actualResponse->getStatus());
+        $this->assertSame(HttpStatus::OK, $actualResponse->getStatus());
         $this->assertSame(
             'https://labrador.example.com',
             $actualResponse->getHeader('Access-Control-Allow-Origin')


### PR DESCRIPTION
This PR fixes #34 .

It also drop support for amphp v2 so it requires a new major version to be release.

I also noticed that you have unconventional usages for code style and I'm sorry if I didn't managed to follow it: there's no PHP cs fixer in the project. (having it would be a nice addition!)

Thanks for the package, and I hope you'll like this one.