### PR TITLE
Use constructor property promotion in ConfigurationBuilder::build

### DIFF
--- a/src/ConfigurationBuilder.php
+++ b/src/ConfigurationBuilder.php
@@ -68,20 +68,14 @@ class ConfigurationBuilder {
             $this->allowedHeaders,
             $this->exposableHeaders,
             $this->allowCredentials) implements Configuration {
-            private $origins;
-            private $methods;
-            private $maxAge;
-            private $allowedHeaders;
-            private $exposableHeaders;
-            private $allowCredentials;
 
             public function __construct(
-                array $origins,
-                array $methods,
-                ?int $maxAge,
-                array $allowedHeaders,
-                array $exposableHeaders,
-                bool $allowCredentials
+                private array $origins,
+                private array $methods,
+                private ?int $maxAge,
+                private array $allowedHeaders,
+                private array $exposableHeaders,
+                private bool $allowCredentials
             ) {
                 $this->origins = $origins;
                 $this->methods = $methods;

--- a/src/ConfigurationBuilder.php
+++ b/src/ConfigurationBuilder.php
@@ -77,12 +77,6 @@ class ConfigurationBuilder {
                 private array $exposableHeaders,
                 private bool $allowCredentials
             ) {
-                $this->origins = $origins;
-                $this->methods = $methods;
-                $this->maxAge = $maxAge;
-                $this->allowedHeaders = $allowedHeaders;
-                $this->exposableHeaders = $exposableHeaders;
-                $this->allowCredentials = $allowCredentials;
             }
 
             /**


### PR DESCRIPTION
This pull request does not change anything in the code logic, it just uses the new php 8.0 feature, [Constructor property promotion](https://www.php.net/releases/8.0/en.php#constructor-property-promotion)